### PR TITLE
Make push() calls in a separate thread

### DIFF
--- a/blocks/extras/extensions/plot.py
+++ b/blocks/extras/extensions/plot.py
@@ -1,7 +1,9 @@
 import logging
 import signal
 import time
+from six.moves.queue import PriorityQueue
 from subprocess import Popen, PIPE
+from threading import Thread
 
 try:
     from bokeh.plotting import (curdoc, cursession, figure, output_server,
@@ -115,7 +117,15 @@ class Plot(SimpleExtension):
 
         kwargs.setdefault('after_epoch', True)
         kwargs.setdefault("before_first_epoch", True)
+        kwargs.setdefault("after_training", True)
         super(Plot, self).__init__(**kwargs)
+
+    @property
+    def push_thread(self):
+        if not hasattr(self, '_push_thread'):
+            self._push_thread = PushThread()
+            self._push_thread.start()
+        return self._push_thread
 
     def do(self, which_callback, *args):
         log = self.main_loop.log
@@ -134,9 +144,8 @@ class Plot(SimpleExtension):
                 else:
                     self.plots[key].data['x'].append(iteration)
                     self.plots[key].data['y'].append(value)
-
-                    cursession().store_objects(self.plots[key])
-        push()
+                    self.push_thread.put(self.plots[key], PushThread.PUT)
+        self.push_thread.put(which_callback, PushThread.PUSH)
 
     def _startserver(self):
         if self.start_server:
@@ -157,9 +166,39 @@ class Plot(SimpleExtension):
     def __getstate__(self):
         state = self.__dict__.copy()
         state['sub'] = None
+        state.pop('_push_thread', None)
         return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._startserver()
         curdoc().add(*self.p)
+
+
+class PushThread(Thread):
+
+    # Define priority constants
+    PUSH = 1
+    PUT = 2
+
+    def __init__(self):
+        super(PushThread, self).__init__()
+        self.queue = PriorityQueue()
+        self.setDaemon(True)
+
+    def put(self, obj, priority):
+        self.queue.put((priority, obj))
+
+    def run(self):
+        while True:
+            priority, obj = self.queue.get()
+            if priority == PushThread.PUT:
+                cursession().store_objects(obj)
+            elif priority == PushThread.PUSH:
+                push()
+                # delete queued objects when training has finished
+                if obj == "after_training":
+                    with self.queue.mutex:
+                        del self.queue.queue[:]
+                    break
+            self.queue.task_done()


### PR DESCRIPTION
`Plot` extension slows down the training time for small datasets. It happens when batch processing is faster than `store_objects()`/`push()` actions to the bokeh server. This is the profiling for a [softmax training with the Iris dataset](https://gist.github.com/johnarevalo/e952e4a3032f6f523dd5). :
```
Section                                  Time     % of total
------------------------------------------------------------
Before training                          0.00          0.00%
  TrainingDataMonitoring                 0.00          0.00%
  Timing                                 0.00          0.00%
  Plot                                   0.00          0.00%
  FinishAfter                            0.00          0.00%
  Other                                  0.00          0.00%
Initialization                           0.60          0.86%
Training                                69.52         99.14%
  Before epoch                           0.12          0.17%
    TrainingDataMonitoring               0.01          0.01%
    Timing                               0.01          0.01%
    Plot                                 0.09          0.13%
    FinishAfter                          0.00          0.01%
    Other                                0.01          0.01%
  Epoch                                  2.97          4.24%
    Read data                            0.26          0.37%
    Before batch                         0.16          0.23%
      TrainingDataMonitoring             0.04          0.05%
      Timing                             0.03          0.05%
      Plot                               0.03          0.05%
      FinishAfter                        0.02          0.03%
      Other                              0.04          0.06%
    Train                                1.78          2.54%
    After batch                          0.70          1.00%
      TrainingDataMonitoring             0.57          0.82%
      Timing                             0.03          0.05%
      Plot                               0.03          0.05%
      FinishAfter                        0.02          0.03%
      Other                              0.05          0.06%
    Other                                0.07          0.10%
  After epoch                           66.40         94.68%
    TrainingDataMonitoring               0.01          0.01%
    Timing                               0.02          0.03%
    Plot                                66.35         94.61%
    FinishAfter                          0.01          0.01%
    Other                                0.01          0.02%
  Other                                  0.03          0.05%
After training                           0.00          0.00%
  TrainingDataMonitoring                 0.00          0.00%
  Timing                                 0.00          0.00%
  Plot                                   0.00          0.00%
  FinishAfter                            0.00          0.00%
  Other                                  0.00          0.00%
```
This is the profiling when `push()` are called from a separate thread:
```
Section                                  Time     % of total
------------------------------------------------------------
Before training                          0.00          0.01%
  TrainingDataMonitoring                 0.00          0.01%
  Timing                                 0.00          0.00%
  Plot                                   0.00          0.00%
  FinishAfter                            0.00          0.00%
  Other                                  0.00          0.00%
Initialization                           0.58         14.09%
Training                                 3.53         85.89%
  Before epoch                           0.04          0.87%
    TrainingDataMonitoring               0.01          0.18%
    Timing                               0.01          0.17%
    Plot                                 0.01          0.24%
    FinishAfter                          0.00          0.09%
    Other                                0.01          0.19%
  Epoch                                  3.38         82.09%
    Read data                            0.25          6.14%
    Before batch                         0.18          4.27%
      TrainingDataMonitoring             0.04          0.91%
      Timing                             0.03          0.82%
      Plot                               0.05          1.13%
      FinishAfter                        0.02          0.46%
      Other                              0.04          0.96%
    Train                                2.09         50.80%
    After batch                          0.79         19.19%
      TrainingDataMonitoring             0.64         15.64%
      Timing                             0.03          0.85%
      Plot                               0.05          1.14%
      FinishAfter                        0.02          0.47%
      Other                              0.05          1.10%
    Other                                0.07          1.68%
  After epoch                            0.10          2.41%
    TrainingDataMonitoring               0.01          0.17%
    Timing                               0.02          0.49%
    Plot                                 0.06          1.42%
    FinishAfter                          0.01          0.13%
    Other                                0.01          0.20%
  Other                                  0.02          0.51%
After training                           0.00          0.01%
  TrainingDataMonitoring                 0.00          0.00%
  Timing                                 0.00          0.00%
  Plot                                   0.00          0.00%
  FinishAfter                            0.00          0.00%
  Other                                  0.00          0.00%
```
The time in `Training` section decreases from `69.52` to `3.53` seconds.