### PR TITLE
README: Remove namespace packages, add Plot note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,30 +17,20 @@ Clone to a directory of your choice.
 
    $ git clone git@github.com:mila-udem/blocks-extras.git
 
-Because of `limitations in pip`_ it is important that you install ``blocks-extras``
-the same way that you installed Blocks. So, if you installed Blocks in editable mode,
-use the command:
-
-.. code-block:: bash
-
-   $ pip install -e .
-   
-And if you installed Blocks in the normal mode (so using ``pip install`` without ``-e``)
-then run this from the directory you just cloned instead:
-
-.. code-block:: bash
-
-   $ pip install .
-   
-Note that you `might have problems`_ with namespace packages if you try to install using
-``python setup.py develop``.
-
-.. _limitations in pip: https://github.com/pypa/pip/issues/3
-.. _might have problems: https://github.com/pypa/packaging-problems/issues/12
-
 Usage
 -----
 
 .. code-block:: python
 
    from blocks_extras.extensions.plotting import Plot
+
+A Note about ``Plot``
+---------------------
+Due to significant architectural changes upstream in Bokeh_, the `Plot` extension
+is currently incompatible with Bokeh ≥ 0.11. A reimagined ``Plot`` extension will
+probably require some sort of data storage backend of its own. Please see
+``blocks-extras`` issue #35 if you are interested in helping move this situation
+forward. Until then, please use Bokeh 0.10 if you are interested in using the `Plot`
+extension.
+
+.. _Bokeh: http://bokeh.pydata.org/

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,9 @@ A Note about ``Plot``
 Due to significant architectural changes upstream in Bokeh_, the `Plot` extension
 is currently incompatible with Bokeh ≥ 0.11. A reimagined ``Plot`` extension will
 probably require some sort of data storage backend of its own. Please see
-``blocks-extras`` issue #35 if you are interested in helping move this situation
+``blocks-extras`` issue `#35`_ if you are interested in helping move this situation
 forward. Until then, please use Bokeh 0.10 if you are interested in using the `Plot`
 extension.
 
 .. _Bokeh: http://bokeh.pydata.org/
+.. _#35: http://github.com/mila-udem/blocks-extras/issues/35


### PR DESCRIPTION
Namespace package warnings no longer relevant in the post-namespace-package era. The fact that Plot is broken with bokeh 0.11 is a bit of a downer though.