### PR TITLE
First refactoring of new SequenceGenerator

### DIFF
--- a/blocks_extras/bricks/sequence_generator2.py
+++ b/blocks_extras/bricks/sequence_generator2.py
@@ -139,9 +139,7 @@ class MergeReadout(AbstractReadout):
 
     @application
     def merge(self, **inputs):
-        merged = self.merge_brick.apply(
-            **{name: inputs[name]
-               for name in self.merge_brick.input_names})
+        merged = self.merge_brick.apply(**inputs)
         merged = self.post_merge.apply(merged)
         return merged
 
@@ -177,7 +175,7 @@ class SoftmaxReadout(MergeReadout, Random):
     def costs(self, prediction, prediction_mask,
               groundtruth, groundtruth_mask, **inputs):
         log_probs = self.all_scores(
-            prediction, self.merge(**dict_subset(inputs, self.merge_inputs)))
+            prediction, self.merge(**dict_subset(inputs, self.merge_names)))
         if not prediction_mask:
             prediction_mask = 1
         return -(log_probs * prediction_mask).sum(axis=0)

--- a/blocks_extras/bricks/sequence_generator2.py
+++ b/blocks_extras/bricks/sequence_generator2.py
@@ -139,8 +139,9 @@ class MergeReadout(AbstractReadout):
 
     @application
     def merge(self, **inputs):
-        merged = self.merge_brick.apply(**{name: inputs[name]
-                                     for name in self.merge_brick.input_names})
+        merged = self.merge_brick.apply(
+            **{name: inputs[name]
+               for name in self.merge_brick.input_names})
         merged = self.post_merge.apply(merged)
         return merged
 

--- a/tests/bricks/test_sequence_generator2.py
+++ b/tests/bricks/test_sequence_generator2.py
@@ -10,8 +10,8 @@ class TestReadouts(object):
 
     def setUp(self):
         self.readout = SoftmaxReadout(
-            merged_states=['states1', 'states2'],
-            dim=4, state_dims=[2, 3],
+            input_names=['states1', 'states2'],
+            num_tokens=4, input_dims=[2, 3],
             weights_init=Uniform(width=1.0),
             biases_init=Uniform(width=1.0),
             seed=1)
@@ -29,7 +29,7 @@ class TestReadouts(object):
             + self.readout.post_merge.parameters[0].get_value())
 
     def test_merge(self):
-        assert self.readout.merged_dim == self.readout.dim
+        assert self.readout.merge_dim == self.readout.num_tokens
         merged = self.readout._merge(states1=self.states1, states2=self.states2).eval()
         assert_equal(merged, self.merged)
 


### PR DESCRIPTION
A few changes:

- let `Readout` use contexts for computation of the cost - can be necessary for some advanced methods, such as e.g. REINFORCE with baseline
- simplify `Readout` and `Feedback` interfaces by using simple property names such as `input_dims` and `output_dims`
- separates `AbstractReadout` and `MergeReadout`. Let interface be separated from the implementation!

@pbrakel, you can have a say! 