### PR TITLE
Added PredictDataStream extension and corresponding test

### DIFF
--- a/blocks_extras/extensions/predict.py
+++ b/blocks_extras/extensions/predict.py
@@ -1,0 +1,53 @@
+from collections import OrderedDict
+import numpy
+import pickle
+
+from blocks.extensions import SimpleExtension
+from blocks.graph import ComputationGraph
+
+
+class PredictDataStream(SimpleExtension):
+    """Generate predictions for a given datastream.
+
+    Parameters
+    ----------
+    data_stream : `~fuel.streams.DataStream`
+        Data stream for which to generate predictions.
+    variables : list of `~theano.TensorVariable`
+        The variables to evaluate.
+    path : str, optional
+        The destination path for pickling. If not given, the prediction
+        will not be saved, but will be stored in the `prediction` attribute
+        instead.
+
+    Attributes
+    ----------
+    prediction : `numpy.ndarray`
+        Storage for predictions.
+    """
+    def __init__(self, data_stream, variables, path=None, **kwargs):
+        self.data_stream = data_stream
+        self.variables = variables
+        self.path = path
+        self.prediction = None
+
+        kwargs.setdefault('after_training', True)
+        super(PredictDataStream, self).__init__(**kwargs)
+
+        cg = ComputationGraph(variables)
+        self.theano_function = cg.get_theano_function()
+
+    def do(self, which_callback, *args):
+        """Generate predictions for the given datastream."""
+        predictions = OrderedDict([(var.name, []) for var in self.variables])
+        for batch in self.data_stream.get_epoch_iterator(as_dict=True):
+            prediction = self.theano_function(**batch)
+            for var, pred in zip(self.variables, prediction):
+                predictions[var.name].append(pred)
+
+        # accumulate predictions for the entire epoch
+        for var in self.variables:
+            predictions[var.name] = numpy.concatenate(predictions[var.name],
+                                                      axis=0)
+        if self.path is not None:
+            pickle.dump(predictions, open(self.path, 'wb'))

--- a/blocks_extras/extensions/predict.py
+++ b/blocks_extras/extensions/predict.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
+
 import numpy
-import pickle
 
 from blocks.extensions import SimpleExtension
 from blocks.graph import ComputationGraph
@@ -53,4 +53,4 @@ class PredictDataStream(SimpleExtension):
             predictions[var.name] = numpy.concatenate(predictions[var.name],
                                                       axis=0)
         if self.path is not None:
-            pickle.dump(predictions, open(self.path, 'wb'))
+            numpy.savez(self.path, **predictions)

--- a/blocks_extras/extensions/predict.py
+++ b/blocks_extras/extensions/predict.py
@@ -7,23 +7,26 @@ from blocks.graph import ComputationGraph
 
 
 class PredictDataStream(SimpleExtension):
-    """Generate predictions for a given datastream.
+    """Evaluate tensors for a given datastream.
 
     Parameters
     ----------
     data_stream : `~fuel.streams.DataStream`
-        Data stream for which to generate predictions.
+        Data stream for which to evaluate.
     variables : list of `~theano.TensorVariable`
         The variables to evaluate.
     path : str, optional
-        The destination path for pickling. If not given, the prediction
-        will not be saved, but will be stored in the `prediction` attribute
-        instead.
+        The destination path for pickling. If not given, the output
+        will not be saved, but will be stored in the `prediction`
+        attribute instead.
 
     Attributes
     ----------
-    prediction : `numpy.ndarray`
-        Storage for predictions.
+    prediction : `collections.OrderedDict`
+        Storage for tensor evaluations. Maps tensor names to outputs
+        of type `numpy.ndarray`. If the callback has not been invoked,
+        this attribute is set to None.
+
     """
     def __init__(self, data_stream, variables, path=None, **kwargs):
         self.data_stream = data_stream
@@ -38,7 +41,7 @@ class PredictDataStream(SimpleExtension):
         self.theano_function = cg.get_theano_function()
 
     def do(self, which_callback, *args):
-        """Generate predictions for the given datastream."""
+        """Evaluate tensors for the given datastream."""
         predictions = OrderedDict([(var.name, []) for var in self.variables])
         for batch in self.data_stream.get_epoch_iterator(as_dict=True):
             prediction = self.theano_function(**batch)

--- a/tests/extensions/test_predict.py
+++ b/tests/extensions/test_predict.py
@@ -1,0 +1,47 @@
+import numpy
+import os
+import pickle
+from collections import OrderedDict
+from tempfile import gettempdir
+
+from theano import tensor
+
+from fuel.schemes import SequentialScheme
+from fuel.datasets import IndexableDataset
+from fuel.streams import DataStream
+from blocks.utils.testing import MockMainLoop
+from blocks.extensions import FinishAfter
+from blocks_extras.extensions.predict import PredictDataStream
+
+
+def test_predict():
+    tempfile = os.path.join(gettempdir(), 'test_predict.pkl')
+
+    # set up mock datastream
+    source = [[1], [2], [3], [4]]
+    dataset = IndexableDataset(OrderedDict([('input', source)]))
+    scheme = SequentialScheme(dataset.num_examples, batch_size=2)
+    data_stream = DataStream(dataset, iteration_scheme=scheme)
+
+    # simulate small "network" that increments the input by 1
+    input_tensor = tensor.matrix('input')
+    output_tensor = input_tensor + 1
+    output_tensor.name = 'output_tensor'
+
+    main_loop = MockMainLoop(extensions=[
+        PredictDataStream(data_stream=data_stream,
+                          variables=[output_tensor],
+                          path=tempfile,
+                          after_training=True),
+        FinishAfter(after_n_epochs=1)
+    ])
+    main_loop.run()
+
+    # assert resulting prediction is saved
+    prediction = pickle.load(open(tempfile, 'rb'))
+    assert numpy.all(prediction[output_tensor.name] == numpy.array(source) + 1)
+
+    try:
+        os.remove(tempfile)
+    except:
+        pass

--- a/tests/extensions/test_predict.py
+++ b/tests/extensions/test_predict.py
@@ -1,8 +1,8 @@
-import numpy
 import os
-import pickle
 from collections import OrderedDict
 from tempfile import gettempdir
+
+import numpy
 
 from theano import tensor
 
@@ -15,7 +15,7 @@ from blocks_extras.extensions.predict import PredictDataStream
 
 
 def test_predict():
-    tempfile = os.path.join(gettempdir(), 'test_predict.pkl')
+    tempfile_path = os.path.join(gettempdir(), 'test_predict.npz')
 
     # set up mock datastream
     source = [[1], [2], [3], [4]]
@@ -31,17 +31,17 @@ def test_predict():
     main_loop = MockMainLoop(extensions=[
         PredictDataStream(data_stream=data_stream,
                           variables=[output_tensor],
-                          path=tempfile,
+                          path=tempfile_path,
                           after_training=True),
         FinishAfter(after_n_epochs=1)
     ])
     main_loop.run()
 
     # assert resulting prediction is saved
-    prediction = pickle.load(open(tempfile, 'rb'))
+    prediction = numpy.load(tempfile_path)
     assert numpy.all(prediction[output_tensor.name] == numpy.array(source) + 1)
 
     try:
-        os.remove(tempfile)
+        os.remove(tempfile_path)
     except:
         pass


### PR DESCRIPTION
Extension that evaluates tensors for a given datastream. Typical use case is when you want to generate predictions for a test set. If indicated, predictions are pickled and saved. I chose pickle over numpy.save because it allowed me to map the tensor names to arrays - sadly, using the tensor itself as key resulted in KeyErrors. 

It's possible that `MonitoredQuantity` or `DatasetEvaluator` could be used instead, but @dwf warned me in [this issue](https://github.com/mila-udem/blocks/issues/1033) that concatenating after every step (using e.g. a Concatenate aggregation scheme) was probably going to be more memory-intensive than concatenating once at the end of the callback.