### PR TITLE
Pass only a subset of inputs to self.merge

### DIFF
--- a/blocks_extras/bricks/sequence_generator2.py
+++ b/blocks_extras/bricks/sequence_generator2.py
@@ -187,7 +187,8 @@ class SoftmaxReadout(MergeReadout, Random):
 
     @application
     def scores(self, **inputs):
-        return self.softmax.log_probabilities(self.merge(**inputs))
+        return self.softmax.log_probabilities(self.merge(
+            **dict_subset(inputs, self.merge_names)))
 
     @application
     def sample(self, **inputs):


### PR DESCRIPTION
Sequence generators v2.0 were never properly finished, however it is essential to fix this bug because some code actually uses them. Methods `scores` and `costs` are supposed to receive more inputs than method `merge` can handle. Therefore, when they call `merge`, they should select only those necessary for `merge` by doing `dict_subset(inputs, self.merge_names)`. In `costs` this has already been implemented, time to add it to `scores` as well.

Since in this repository tests and peer review are optional, I will merge this PR in the nearest future.
